### PR TITLE
refactor styling tokens

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=HarmonyOS+Sans:wght@400;500;600;700&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -64,7 +61,7 @@ body {
   color: var(--primary-text);
   background: var(--base-bg);
   min-height: 100vh;
-  font-family: 'Inter', 'HarmonyOS Sans', 'Source Han Sans SC', 'Helvetica Neue', Arial, sans-serif;
+  font-family: var(--font-noto), var(--font-inter), 'Source Han Sans SC', 'Helvetica Neue', Arial, sans-serif;
   font-weight: 400;
   line-height: 1.5;
   letter-spacing: 0;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,14 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Inter, Noto_Sans_SC } from "next/font/google";
 import "./globals.css";
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({ subsets: ["latin"], display: "swap", variable: "--font-inter" });
+const noto = Noto_Sans_SC({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+  variable: "--font-noto",
+});
 
 export const metadata: Metadata = {
   title: "Sparkit - AI Image Generation Tool",
@@ -16,7 +22,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={`${inter.variable} ${noto.variable}`}>{children}</body>
     </html>
   );
 }

--- a/components/ImageGenerator.tsx
+++ b/components/ImageGenerator.tsx
@@ -100,7 +100,7 @@ export function ImageGenerator() {
             Generate Images
           </h2>
         </div>
-        <p className="text-gray-400 max-w-2xl mx-auto">
+        <p className="text-secondary-text max-w-2xl mx-auto">
           Describe your vision and let AI bring it to life with stunning visuals
         </p>
       </div>
@@ -108,7 +108,7 @@ export function ImageGenerator() {
       <div className="space-y-6">
         {/* Prompt Input */}
         <div className="space-y-3">
-          <label className="block text-sm font-semibold text-gray-300">
+          <label className="block text-sm font-semibold text-primary-text">
             Describe your image
           </label>
           <div className="relative">
@@ -116,7 +116,7 @@ export function ImageGenerator() {
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
               placeholder="A majestic mountain landscape at sunset with aurora borealis dancing in the sky..."
-              className="w-full p-4 bg-black/20 border border-white/10 rounded-2xl focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500/50 resize-none text-white placeholder-gray-400 backdrop-blur-sm transition-all duration-300"
+              className="w-full p-4 bg-black/20 border border-white/10 rounded-2xl focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500/50 resize-none text-primary-text placeholder-secondary-text backdrop-blur-sm transition-all duration-300"
               rows={4}
             />
             {prompt && (
@@ -125,7 +125,7 @@ export function ImageGenerator() {
                 className="absolute top-3 right-3 p-2 rounded-lg bg-white/10 hover:bg-white/20 transition-colors"
                 title="Copy prompt"
               >
-                <Copy className="w-4 h-4 text-gray-400" />
+                <Copy className="w-4 h-4 text-secondary-text" />
               </button>
             )}
           </div>
@@ -133,7 +133,7 @@ export function ImageGenerator() {
 
         {/* Image Count Selector */}
         <div className="space-y-3">
-          <label className="block text-sm font-semibold text-gray-300">
+          <label className="block text-sm font-semibold text-primary-text">
             Number of images
           </label>
           <div className="flex gap-2">
@@ -144,7 +144,7 @@ export function ImageGenerator() {
                 className={`px-6 py-3 rounded-xl font-semibold transition-all duration-300 ${
                   count === num
                     ? 'bg-gradient-to-r from-purple-600 to-blue-600 text-white shadow-lg'
-                    : 'bg-white/10 text-gray-300 hover:bg-white/20'
+                    : 'bg-white/10 text-primary-text hover:bg-white/20'
                 }`}
               >
                 {num} {num === 1 ? 'image' : 'images'}
@@ -187,7 +187,7 @@ export function ImageGenerator() {
           <div className="space-y-6">
             <div className="text-center">
               <h3 className="text-xl font-semibold text-white mb-2">Your Generated Images</h3>
-              <p className="text-gray-400">Click to download or copy to clipboard</p>
+              <p className="text-secondary-text">Click to download or copy to clipboard</p>
             </div>
             
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -229,7 +229,7 @@ export function ImageGenerator() {
                   
                   {/* Image info */}
                   <div className="mt-3 text-center">
-                    <p className="text-sm text-gray-400">
+                    <p className="text-sm text-secondary-text">
                       Image {index + 1} of {generatedImages.length}
                     </p>
                   </div>
@@ -245,8 +245,8 @@ export function ImageGenerator() {
             <div className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gradient-to-r from-purple-500/20 to-blue-500/20 mb-4">
               <ImageIcon className="w-10 h-10 text-purple-400" />
             </div>
-            <h3 className="text-lg font-semibold text-gray-300 mb-2">Ready to create?</h3>
-            <p className="text-gray-500">Enter a detailed prompt above to generate your first image</p>
+            <h3 className="text-lg font-semibold text-primary-text mb-2">Ready to create?</h3>
+            <p className="text-disabled-text">Enter a detailed prompt above to generate your first image</p>
           </div>
         )}
       </div>

--- a/components/MainContent.tsx
+++ b/components/MainContent.tsx
@@ -446,7 +446,7 @@ function UpdatesContent() {
   return (
     <div className="space-y-8">
       <div className="text-center">
-        <h2 className="text-3xl font-bold text-white mb-4">What's New</h2>
+        <h2 className="text-3xl font-bold text-white mb-4">What&apos;s New</h2>
         <p className="text-gray-400 max-w-2xl mx-auto">
           Stay updated with the latest features and improvements
         </p>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -53,7 +53,7 @@ export function Sidebar({ activeTab, onTabChange, isCollapsed, onToggleCollapse,
       className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg transition-all duration-200 group ${
         isActive
           ? 'bg-gradient-to-r from-purple-600/20 to-pink-600/20 text-white border border-purple-500/30'
-          : 'text-gray-400 hover:text-white hover:bg-white/5'
+          : 'text-secondary-text hover:text-primary-text hover:bg-white/5'
       }`}
       style={{
         color: isActive ? 'var(--primary-text)' : 'var(--secondary-text)',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,20 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        base: "var(--base-bg)",
+        surface: "var(--surface-bg)",
+        border: "var(--border-color)",
+        primary: "var(--primary-color)",
+        accent: "var(--accent-color)",
+        success: "var(--success-color)",
+        warning: "var(--warning-color)",
+        error: "var(--error-color)",
+        info: "var(--info-color)",
+        "primary-text": "var(--primary-text)",
+        "secondary-text": "var(--secondary-text)",
+        "disabled-text": "var(--disabled-text)",
+      },
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":


### PR DESCRIPTION
## Summary
- load Inter and Noto Sans SC with next/font and remove external font imports
- map design tokens into Tailwind theme and use them in components
- configure ESLint with Next.js defaults and fix unescaped apostrophe in updates section

## Testing
- `npm run lint`
- `npm run build` *(fails: blocked from fetching fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdea276dc832d8a56e642041ec366